### PR TITLE
Denormalize join tables to save money

### DIFF
--- a/db/migrate/20220124022943_add_new_tag_ids_to_article.rb
+++ b/db/migrate/20220124022943_add_new_tag_ids_to_article.rb
@@ -1,0 +1,5 @@
+class AddNewTagIdsToArticle < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :new_tag_ids, :integer, array: true, default: []
+  end
+end

--- a/db/migrate/20220124025959_add_new_machine_ids_to_article.rb
+++ b/db/migrate/20220124025959_add_new_machine_ids_to_article.rb
@@ -1,0 +1,5 @@
+class AddNewMachineIdsToArticle < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :new_machine_ids, :integer, array: true, default: []
+  end
+end

--- a/lib/tasks/denormalize_machines.rake
+++ b/lib/tasks/denormalize_machines.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'rake'
+
+namespace :articles do
+  task denormalize_machines: :environment do
+    Article.all.each do |a|
+      a.new_machine_ids = a.machine_ids
+      a.save!
+      print '.'
+    end
+
+    puts
+    puts "Done."
+  end
+end

--- a/lib/tasks/denormalize_tags.rake
+++ b/lib/tasks/denormalize_tags.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'rake'
+
+namespace :articles do
+  task denormalize_tags: :environment do
+    Article.all.each do |a|
+      a.new_tag_ids = a.tag_ids
+      a.save!
+      print '.'
+    end
+
+    puts
+    puts "Done."
+  end
+end


### PR DESCRIPTION
The free Heroku PSQL DB has a limit of 10k rows.

Unfortunately, nice, normalized JOIN tables eat rows. So `articles_tags` and `articles_machines` need to get folded into the articles tables as PSQL array columns.